### PR TITLE
Adding Getting started client overview for Java

### DIFF
--- a/pages/docs/getting-started/clients/java.html
+++ b/pages/docs/getting-started/clients/java.html
@@ -2,14 +2,62 @@ title: Connecting to Crate with Java
 author: Chris Ward
 
 ## JDBC
-### Maven
-The simplest way to connect to a Crate cluster with the Crate JDBC driver is to visit the drivers page on [Bintray](https://bintray.com/crate/crate/crate-jdbc/view) and click the 'Set Me Up' button. This will give you Maven settings that can be pasted into your current project or downloaded for a new project.
 
-### Gradle
+### Add Crate to your Project
+The simplest way to connect to a Crate cluster with the Crate JDBC driver is to visit the drivers page on [Bintray](https://bintray.com/crate/crate/crate-jdbc/view) and click the 'Set Me Up' button. This will give you the Maven or Gradle configuration that can be pasted into your current project or downloaded for a new project.
+
+For manual.
+
+#### Maven
+
+Add the following to your _pom.xml_ file:
+
+```xml
+...
+<repositories>
+    ...
+    <repository>
+        <snapshots>
+            <enabled>false</enabled>
+        </snapshots>
+        <id>central</id>
+        <name>bintray</name>
+        <url>http://dl.bintray.com/crate/crate</url>
+    </repository>
+</repositories>
+...
+<dependencies>
+    ...
+    <dependency>
+        <groupId>io.crate</groupId>
+        <artifactId>crate-jdbc</artifactId>
+        <version>...</version>
+    </dependency>
+</dependencies>
+...
+```
+
+#### Gradle
+Add Crate as a dependency to your Gradle file:
+
 ```gradle
-repositories {
-    maven {
-        url  "http://dl.bintray.com/crate/crate"
+   repositories {
+        ...
+        jcenter()
     }
-}
+
+    dependencies {
+        compile 'io.crate:crate-jdbc:...'
+        ...
+    }
+```
+
+### Connect to Crate
+The Crate JDBC driver class is `io.crate.client.jdbc.CrateDriver`.
+
+Connect to your Crate cluster with the Java DriverManager:
+
+```java
+Class.forName("io.crate.client.jdbc.CrateDriver");
+Connection conn = DriverManager.getConnection("crate://SERVER_IP:4300");
 ```

--- a/pages/docs/getting-started/clients/java.html
+++ b/pages/docs/getting-started/clients/java.html
@@ -1,0 +1,15 @@
+title: Connecting to Crate with Java
+author: Chris Ward
+
+## JDBC
+### Maven
+The simplest way to connect to a Crate cluster with the Crate JDBC driver is to visit the drivers page on [Bintray](https://bintray.com/crate/crate/crate-jdbc/view) and click the 'Set Me Up' button. This will give you Maven settings that can be pasted into your current project or downloaded for a new project.
+
+### Gradle
+```gradle
+repositories {
+    maven {
+        url  "http://dl.bintray.com/crate/crate"
+    }
+}
+```

--- a/pages/docs/getting-started/clients/php.html
+++ b/pages/docs/getting-started/clients/php.html
@@ -1,0 +1,92 @@
+title: Connecting to Crate with PHP
+author: Chris Ward
+
+Crate supports integration with the [PDO](http://php.net/manual/en/intro.pdo.php) and [DBAL](http://www.doctrine-project.org/projects/dbal.html) data abstraction layers.
+
+## PDO
+### Installation
+Install the driver by adding a dependency to your _composer.json_ file:
+
+```json
+{
+  "require": {
+    "crate/crate-pdo":"~0.3.0"
+  }
+}
+```
+
+And installing with `composer intall`.
+
+### Connect to Crate
+To connect to your cluster, Crate follows standard PDO syntax to form a data source name string ([dsn](https://en.wikipedia.org/wiki/Data_source_name)) and then connect to it.
+
+```php
+$dsn = 'crate:host=SERVER_IP;dbname=doc';
+$connection = new PDO($dsn, null, null, null);
+```
+
+As Crate doesn't support authentication, the other parameters can be left null.
+
+## DBAL
+### Installation
+Install the driver by adding a dependency to your _composer.json_ file:
+
+```json
+{
+  "require": {
+    "crate/crate-dbal":"~0.2.0"
+  }
+}
+```
+
+And installing with `composer intall`.
+
+### Connect to Crate
+To connect to your cluster, Crate follows standard DBAL syntax to create an array of parameters and then create a connection.
+
+```php
+$params = array(
+    'driverClass' => 'Crate\DBAL\Driver\PDOCrate\Driver',
+    'host' => 'SERVER_IP',
+    'port' => 4200
+);
+
+$connection = \Doctrine\DBAL\DriverManager::getConnection($params);
+$schemaManager = $connection->getSchemaManager();
+```
+
+### ORM
+If you are using Doctrine's ORM features, then an extra dependency is needed in your _composer.json_ file.
+
+```json
+{
+  "require": {
+    "crate/crate-dbal":"~0.2.0",
+    "doctrine/orm": "*"
+  }
+}
+```
+
+To create a connection:
+
+```php
+require_once "vendor/autoload.php";
+
+use Doctrine\ORM\Tools\Setup;
+use Doctrine\ORM\EntityManager;
+
+$paths = array("/path/to/entity-files");
+$isDevMode = false;
+
+// the connection configuration
+$params = array(
+    'driverClass' => 'Crate\DBAL\Driver\PDOCrate\Driver',
+    'host' => 'SERVER_IP',
+    'port' => 4200
+);
+
+$config = Setup::createAnnotationMetadataConfiguration($paths, $isDevMode);
+$entityManager = EntityManager::create($params, $config);
+```
+
+Setting up the Doctrine ORM requires some extra steps, and we suggest reading [the official Doctrine documentation](http://doctrine-orm.readthedocs.org/en/latest/index.html) to get started.

--- a/pages/docs/getting-started/local/linux.html
+++ b/pages/docs/getting-started/local/linux.html
@@ -190,7 +190,15 @@ sudo apt-get update
 sudo apt-get install crate
 ```
 
-#### Testing and Unstable Releases
+### Start Crate
+Crate should have been started automatically by upstart and can be stopped or restarted with:
+
+```bash
+sudo service crate stop
+sudo service crate restart
+```
+
+### Testing and Unstable Releases
 The Crate Testing repository is disabled by default, it contains development builds and is frequently updated. The packages are waiting for feedback from testers on functionality and stability. Packages in this repository will change during development, so it should be disabled on production systems. If you want to enable the Testing repo on your server. To enable the Testing Repository on your machine add the PPA:
 
 ```bash


### PR DESCRIPTION
@kovrus You're now the JDBC driver owner!

This is a very quick overview page for the 'Getting Started' area of the documentation, it's just meant to cover getting the client and connecting to a cluster.

I struggled to get the current instructions for the driver to work, but I'm not sure if this was due to my own Java ignorance or if there is something wrong with the driver. Could you double check that these steps work for you and let me know if there any other things you want changed?