### PR TITLE
fix date ordering of posts in feed xml

### DIFF
--- a/pages/feed/index.xml
+++ b/pages/feed/index.xml
@@ -22,7 +22,7 @@
       <description>{{ post.raw_body|markdown|striptags|truncatewords:50 }}</description>
       <link>{{ CONFIG.site }}{{ post.url }}</link>
       <guid isPermaLink="false">{{ post.url }}</guid>
-      <pubDate>{{ post.date|date:"c" }}</pubDate>
+      <pubDate>{{ post.date|date:"D, d M Y H:i:s" }}</pubDate>
     </item>
     {% endfor %}
   </channel>

--- a/plugins/collection.py
+++ b/plugins/collection.py
@@ -36,8 +36,6 @@ from django.utils.safestring import mark_safe
 
 from web.utils import toDict, parseDate, parsePost
 
-from email import utils
-
 COLLECTIONS = dict()
 COLLECTIONS_JSON = dict()
 # legacy stuff
@@ -111,8 +109,7 @@ class Collection(object):
 
     @staticmethod
     def to_datetime(headers):
-        timestamp_tuple = parseDate(headers.get('date') or headers.get('created')).timetuple()
-        return utils.formatdate(time.mktime(timestamp_tuple))
+        return parseDate(headers.get('date') or headers.get('created'))
 
     def filter(self, value, key='tags'):
         return filter(lambda p: value in p.get(key), self.pages)


### PR DESCRIPTION
Causes wrong order in feed list
<img width="477" alt="screen shot 2016-01-23 at 12 51 45" src="https://cloud.githubusercontent.com/assets/6863216/12530023/18978204-c1d0-11e5-80c2-fc0faf64ab2d.png">