### PR TITLE
Fix up typos in CoreOS install guide

### DIFF
--- a/pages/docs/install/containers/coreos.html
+++ b/pages/docs/install/containers/coreos.html
@@ -1,7 +1,7 @@
 title: Getting started with Crate on CoreOS
 author: Mathias Fußenegger
 
-As a Linux distribution targetted at cloud and cluster based environments, CoreOS is a prefect fit for a Crate cluster.eetctl.
+As a Linux distribution targetted at cloud and cluster based environments, CoreOS is a perfect fit for a Crate cluster.
 
 ## Pre-requisites
 We assume you have a CoreOS cluster running and can access the `fleetctl` tool installed on your local system or on a node in the CoreOS cluster.


### PR DESCRIPTION
As far as I can tell editing the HTML directly is the appropriate method here but let me know if otherwise.