### PR TITLE
fix: automatic download didn’t work

### DIFF
--- a/pages/docs/install/local/download-thanks.html
+++ b/pages/docs/install/local/download-thanks.html
@@ -1,12 +1,7 @@
 title: Thanks for Downloading Crate
 author: Michael Beer
 
-<script type="text/javascript">
-document.addEventListener("DOMContentLoaded", function(event) {
-  var link = document.getElementById('download');
-  link.click();
-});
-</script>
+<META HTTP-EQUIV=Refresh CONTENT="0;URL=https://cdn.crate.io/downloads/releases/crate-{{ CONFIG.stable_version }}.tar.gz"> 
 
 ## Your download should begin automatically.
 


### PR DESCRIPTION
in safari