### PR TITLE
corrected command how to start Crate on Windows

### DIFF
--- a/pages/docs/install/local/windows.html
+++ b/pages/docs/install/local/windows.html
@@ -15,7 +15,7 @@ Allow the ports Crate uses through the Windows Firewall:
 ## Install Crate
 [Download the Crate Tarball](/docs/install/local/tarball/), expand it and move to a convenient location.
 
-Start crate by running `bin/crate`, to create a cluster, run the command multiple times.
+Start Crate by running `.\bin\crate`, to create a cluster, run the command multiple times.
 
 ## Next Steps
 


### PR DESCRIPTION
in Windows quick start guide